### PR TITLE
Replace Header with new Navbar component and update root layout

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,9 +1,0 @@
-const Header = () => {
-  return (
-    <div className="w-full py-4 px-2">
-      <h1>Navbar </h1>
-    </div>
-  );
-};
-
-export default Header;

--- a/client/src/components/ui/Navbar.tsx
+++ b/client/src/components/ui/Navbar.tsx
@@ -1,0 +1,32 @@
+import { Factory } from "lucide-react";
+
+import { Button } from "./button";
+
+const Navbar = () => {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
+          <div className="rounded-md bg-primary/10 p-2 text-primary">
+            <Factory aria-hidden="true" className="size-5" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm text-muted-foreground">Smart PLC Control</span>
+            <h1 className="text-base font-semibold leading-tight text-foreground">
+              Dashboard
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="ghost">
+            Sign in
+          </Button>
+          <Button size="sm">Sign up</Button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -2,7 +2,7 @@ import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 
-import Header from "../components/Header";
+import Navbar from "../components/ui/Navbar";
 
 import appCss from "../styles.css?url";
 
@@ -38,7 +38,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <Header />
+        <Navbar />
         {children}
         <TanStackDevtools
           config={{


### PR DESCRIPTION
### Motivation

- Replace the simple `Header` component with a more fully-featured, styled `Navbar` placed under `components/ui` to provide a sticky top navigation for the dashboard.
- Update the root route so the app shell renders the new `Navbar` instead of the removed `Header`.

### Description

- Deleted `client/src/components/Header.tsx` and added a new `client/src/components/ui/Navbar.tsx` which implements a sticky top navigation with branding, a `Factory` icon from `lucide-react`, and `Sign in`/`Sign up` buttons using the local `Button` component.
- Updated `client/src/routes/__root.tsx` to import `Navbar` from `../components/ui/Navbar` and replaced the rendered `<Header />` with `<Navbar />`.
- The new `Navbar` includes layout and utility classes for positioning and styling (sticky, border, backdrop blur) and retains the application title and subtitle.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a89008ec1c8320910643ec837cbcd3)