### PR TITLE
Add sign-in/sign-up routes and shared AuthForm component; wire Navbar links

### DIFF
--- a/client/src/components/layout/AuthForm.tsx
+++ b/client/src/components/layout/AuthForm.tsx
@@ -1,0 +1,110 @@
+import { Link } from "@tanstack/react-router";
+import { useId } from "react";
+
+import { Button } from "../ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+
+type AuthFormMode = "sign-in" | "sign-up";
+
+type AuthFormProps = {
+	mode: AuthFormMode;
+};
+
+const AuthForm = ({ mode }: AuthFormProps) => {
+	const emailId = useId();
+	const passwordId = useId();
+	const userNameId = useId();
+	const confirmPasswordId = useId();
+	const isSignUp = mode === "sign-up";
+
+	return (
+		<main className="min-h-[calc(100vh-4rem)] bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 px-4 py-10 sm:px-6 lg:px-8">
+			<div className="mx-auto flex h-full w-full max-w-7xl items-center justify-center">
+				<Card className="w-full max-w-md border-slate-700/80 bg-slate-900/80 text-slate-50 backdrop-blur">
+					<CardHeader>
+						<CardTitle>
+							{isSignUp ? "Create your account" : "Welcome back"}
+						</CardTitle>
+						<CardDescription className="text-slate-300">
+							{isSignUp
+								? "Provide username, email, and matching passwords to sign up."
+								: "Sign in with your email and password."}
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<form className="space-y-4" noValidate>
+							{isSignUp ? (
+								<div className="space-y-2">
+									<Label htmlFor={userNameId}>Username</Label>
+									<Input
+										id={userNameId}
+										name="username"
+										placeholder="yourname"
+										required
+									/>
+								</div>
+							) : null}
+
+							<div className="space-y-2">
+								<Label htmlFor={emailId}>Email</Label>
+								<Input
+									id={emailId}
+									name="email"
+									placeholder="you@example.com"
+									required
+									type="email"
+								/>
+							</div>
+
+							<div className="space-y-2">
+								<Label htmlFor={passwordId}>Password</Label>
+								<Input
+									id={passwordId}
+									name="password"
+									required
+									type="password"
+								/>
+							</div>
+
+							{isSignUp ? (
+								<div className="space-y-2">
+									<Label htmlFor={confirmPasswordId}>Confirm password</Label>
+									<Input
+										id={confirmPasswordId}
+										name="confirmPassword"
+										required
+										type="password"
+									/>
+								</div>
+							) : null}
+
+							<Button className="w-full" type="submit">
+								{isSignUp ? "Sign up" : "Sign in"}
+							</Button>
+						</form>
+
+						<p className="mt-4 text-center text-sm text-slate-300">
+							{isSignUp ? "Already have an account?" : "Need an account?"}{" "}
+							<Link
+								className="font-medium text-sky-300 underline-offset-4 hover:underline"
+								to={isSignUp ? "/sign-in" : "/sign-up"}
+							>
+								{isSignUp ? "Sign in" : "Sign up"}
+							</Link>
+						</p>
+					</CardContent>
+				</Card>
+			</div>
+		</main>
+	);
+};
+
+export default AuthForm;

--- a/client/src/components/ui/Navbar.tsx
+++ b/client/src/components/ui/Navbar.tsx
@@ -1,32 +1,37 @@
+import { Link } from "@tanstack/react-router";
 import { Factory } from "lucide-react";
 
 import { Button } from "./button";
 
 const Navbar = () => {
-  return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-      <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center gap-3">
-          <div className="rounded-md bg-primary/10 p-2 text-primary">
-            <Factory aria-hidden="true" className="size-5" />
-          </div>
-          <div className="flex flex-col">
-            <span className="text-sm text-muted-foreground">Smart PLC Control</span>
-            <h1 className="text-base font-semibold leading-tight text-foreground">
-              Dashboard
-            </h1>
-          </div>
-        </div>
+	return (
+		<header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+			<div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+				<div className="flex items-center gap-3">
+					<div className="rounded-md bg-primary/10 p-2 text-primary">
+						<Factory aria-hidden="true" className="size-5" />
+					</div>
+					<div className="flex flex-col">
+						<span className="text-sm text-muted-foreground">
+							Smart PLC Control
+						</span>
+						<h1 className="text-base font-semibold leading-tight text-foreground">
+							Dashboard
+						</h1>
+					</div>
+				</div>
 
-        <div className="flex items-center gap-2">
-          <Button size="sm" variant="ghost">
-            Sign in
-          </Button>
-          <Button size="sm">Sign up</Button>
-        </div>
-      </div>
-    </header>
-  );
+				<div className="flex items-center gap-2">
+					<Button asChild size="sm" variant="ghost">
+						<Link to="/sign-in">Sign in</Link>
+					</Button>
+					<Button asChild size="sm">
+						<Link to="/sign-up">Sign up</Link>
+					</Button>
+				</div>
+			</div>
+		</header>
+	);
 };
 
 export default Navbar;

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -9,8 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignUpRouteImport } from './routes/sign-up'
+import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as IndexRouteImport } from './routes/index'
 
+const SignUpRoute = SignUpRouteImport.update({
+  id: '/sign-up',
+  path: '/sign-up',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SignInRoute = SignInRouteImport.update({
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +31,50 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/sign-in' | '/sign-up'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/sign-in' | '/sign-up'
+  id: '__root__' | '/' | '/sign-in' | '/sign-up'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SignInRoute: typeof SignInRoute
+  SignUpRoute: typeof SignUpRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sign-up': {
+      id: '/sign-up'
+      path: '/sign-up'
+      fullPath: '/sign-up'
+      preLoaderRoute: typeof SignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +87,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SignInRoute: SignInRoute,
+  SignUpRoute: SignUpRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/client/src/routes/sign-in.tsx
+++ b/client/src/routes/sign-in.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import AuthForm from "../components/layout/AuthForm";
+
+export const Route = createFileRoute("/sign-in")({
+	component: SignIn,
+});
+
+function SignIn() {
+	return <AuthForm mode="sign-in" />;
+}

--- a/client/src/routes/sign-up.tsx
+++ b/client/src/routes/sign-up.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import AuthForm from "../components/layout/AuthForm";
+
+export const Route = createFileRoute("/sign-up")({
+	component: SignUp,
+});
+
+function SignUp() {
+	return <AuthForm mode="sign-up" />;
+}


### PR DESCRIPTION
### Motivation
- Introduce dedicated authentication pages for signing in and signing up with a shared UI to avoid duplicating forms. 
- Surface sign-in and sign-up entry points from the global navigation so users can reach auth pages easily. 
- Integrate the new routes with the generated router tree so routing types and lookups include `/sign-in` and `/sign-up`.

### Description
- Added a new reusable `AuthForm` component (`client/src/components/layout/AuthForm.tsx`) that renders a sign-in or sign-up form based on the `mode` prop. 
- Created file routes `client/src/routes/sign-in.tsx` and `client/src/routes/sign-up.tsx` that mount `AuthForm` with `mode="sign-in"` and `mode="sign-up"` respectively. 
- Updated the generated router tree (`client/src/routeTree.gen.ts`) to register the new `/sign-in` and `/sign-up` routes and their types. 
- Updated `Navbar` (`client/src/components/ui/Navbar.tsx`) to use `Link` inside `Button` (via `asChild`) and point to the new auth routes.

### Testing
- Performed a TypeScript type check (`tsc`) against the updated codebase and the compile succeeded. 
- Ran a local dev build/start command (`npm run dev` / dev server) to verify pages render and routing resolves, and the app started without runtime errors. 
- No new automated unit tests were added for the auth form in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8950aa0508320a9218ea20665cd4b)